### PR TITLE
Included all dependencies from Picasso as 28.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,12 @@ android {
 
 dependencies {
 	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation "com.android.support:support-v4:28.0.0"
+	implementation "com.android.support:support-vector-drawable:28.0.0"
+	implementation "com.android.support:design:28.0.0"
+	implementation "com.android.support:animated-vector-drawable:28.0.0"
+	implementation "com.android.support:exifinterface:28.0.0"
+	implementation "com.android.support:support-media-compat:28.0.0"
 	implementation 'com.android.support:design:28.0.0'
 	implementation 'com.google.android.gms:play-services-gcm:16.0.0'
 	implementation 'com.squareup.okhttp3:okhttp:3.11.0'


### PR DESCRIPTION
Gradle have warnings for packages that include older versions of the support libs than whats defined in the gradle file. This change make sure that all support libs included are up to date with the one we use.